### PR TITLE
Fixed bug with select where it would always pick the same action for the start, and not explore all actions for next node

### DIFF
--- a/src/modules/xiv/optimizer/optimizerUtil.ts
+++ b/src/modules/xiv/optimizer/optimizerUtil.ts
@@ -52,24 +52,35 @@ export class MCTSOptimizer {
   }
 
  // Selects the best child node based on visits and score
- select(node: TreeNode): TreeNode {
+// Selects the best child node based on visits and score
+select(node: TreeNode): TreeNode {
     if (LOG_LEVEL === 1) {
         console.log("[LOG] Selecting node. Current children: ", node.children.map(c => c.action?.name));
     }
     if (node.children.length === 0) {
         return node; // No selection possible
     }
-  
-    const selectedNode = node.children.reduce((bestChild, currentChild) => 
-      currentChild.visits === 0 ? currentChild : (bestChild.score > currentChild.score ? bestChild : currentChild),
-      node.children[0] // Ensure we have at least one child to avoid empty reduce
-    );
-  
+
+    // Filter out children that have not been visited
+    const unvisitedChildren = node.children.filter(child => child.visits === 0);
+    
+    let selectedNode;
+    if (unvisitedChildren.length > 0) {
+        // If there are unvisited nodes, pick one randomly
+        selectedNode = unvisitedChildren[Math.floor(Math.random() * unvisitedChildren.length)];
+    } else {
+        // Otherwise, pick the one with the highest score
+        selectedNode = node.children.reduce((bestChild, currentChild) => 
+            bestChild.score > currentChild.score ? bestChild : currentChild
+        );
+    }
+
     if (LOG_LEVEL === 1) {
         console.log("[LOG] Selected node: ", selectedNode.action?.name);
     }
     return selectedNode;
-  }
+}
+
 
   // Expands the current node with all possible child actions
   expand(node: TreeNode): void {
@@ -238,7 +249,7 @@ export class MCTSOptimizer {
       }
       
       // Fetch job actions and start MCTS optimization
-      const result = this.monteCarloTreeSearch(this.root, 100000);
+      const result = this.monteCarloTreeSearch(this.root, 1000);
       this.bestActions = result[0];
       this.bestPotency = result[1];
   }


### PR DESCRIPTION
With higher numbers of iterations and the current score function it is now tending towards optimal, (optimal would be 10 goring blades because it has the highest potency and this score function just multiples all the potencies) 
![image](https://github.com/user-attachments/assets/b700e412-017c-4a80-97c9-bf6e53bc2e11)
